### PR TITLE
Fixing Blynk Auth input pattern at web form (#487)

### DIFF
--- a/examples/Blynk.Inject/Template_ESP32/ConfigMode.h
+++ b/examples/Blynk.Inject/Template_ESP32/ConfigMode.h
@@ -54,7 +54,7 @@ const char* config_form = R"html(
     <table>
     <tr><td><label for="ssid">WiFi SSID:</label></td>  <td><input type="text" name="ssid" length=64 required="required"></td></tr>
     <tr><td><label for="pass">Password:</label></td>   <td><input type="text" name="pass" length=64></td></tr>
-    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
+    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[_-a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
     <tr><td><label for="host">Host:</label></td>       <td><input type="text" name="host" length=64></td></tr>
     <tr><td><label for="port_ssl">Port:</label></td>   <td><input type="number" name="port_ssl" value="443" min="1" max="65535"></td></tr>
     </table><br/>

--- a/examples/Blynk.Inject/Template_ESP8266/ConfigMode.h
+++ b/examples/Blynk.Inject/Template_ESP8266/ConfigMode.h
@@ -56,7 +56,7 @@ const char* config_form = R"html(
     <table>
     <tr><td><label for="ssid">WiFi SSID:</label></td>  <td><input type="text" name="ssid" length=64 required="required"></td></tr>
     <tr><td><label for="pass">Password:</label></td>   <td><input type="text" name="pass" length=64></td></tr>
-    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
+    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[_-a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
     <tr><td><label for="host">Host:</label></td>       <td><input type="text" name="host" length=64></td></tr>
     <tr><td><label for="port_ssl">Port:</label></td>   <td><input type="number" name="port_ssl" value="443" min="1" max="65535"></td></tr>
     </table><br/>

--- a/examples/Blynk.Inject/Template_MKR1000/ConfigMode.h
+++ b/examples/Blynk.Inject/Template_MKR1000/ConfigMode.h
@@ -63,7 +63,7 @@ const char* config_form = R"html(
     <table>
     <tr><td><label for="ssid">WiFi SSID:</label></td>  <td><input type="text" name="ssid" length=64 required="required"></td></tr>
     <tr><td><label for="pass">Password:</label></td>   <td><input type="text" name="pass" length=64></td></tr>
-    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
+    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[_-a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
     <tr><td><label for="host">Host:</label></td>       <td><input type="text" name="host" length=64></td></tr>
     <tr><td><label for="port">Port:</label></td>       <td><input type="number" name="port" value="80" min="1" max="65535"></td></tr>
     </table><br/>

--- a/examples/Blynk.Inject/Template_MKR1010/ConfigMode.h
+++ b/examples/Blynk.Inject/Template_MKR1010/ConfigMode.h
@@ -61,7 +61,7 @@ const char* config_form = R"html(
     <table>
     <tr><td><label for="ssid">WiFi SSID:</label></td>  <td><input type="text" name="ssid" length=64 required="required"></td></tr>
     <tr><td><label for="pass">Password:</label></td>   <td><input type="text" name="pass" length=64></td></tr>
-    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
+    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[_-a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
     <tr><td><label for="host">Host:</label></td>       <td><input type="text" name="host" length=64></td></tr>
     <tr><td><label for="port">Port:</label></td>       <td><input type="number" name="port" value="80" min="1" max="65535"></td></tr>
     </table><br/>

--- a/examples/Blynk.Inject/myPlant_ESP8266/ConfigMode.h
+++ b/examples/Blynk.Inject/myPlant_ESP8266/ConfigMode.h
@@ -56,7 +56,7 @@ const char* config_form = R"html(
     <table>
     <tr><td><label for="ssid">WiFi SSID:</label></td>  <td><input type="text" name="ssid" length=64 required="required"></td></tr>
     <tr><td><label for="pass">Password:</label></td>   <td><input type="text" name="pass" length=64></td></tr>
-    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
+    <tr><td><label for="blynk">Auth token:</label></td><td><input type="text" name="blynk" placeholder="a0b1c2d..." pattern="[_-a-zA-Z0-9]{32}" maxlength="32" required="required"></td></tr>
     <tr><td><label for="host">Host:</label></td>       <td><input type="text" name="host" length=64></td></tr>
     <tr><td><label for="port_ssl">Port:</label></td>   <td><input type="number" name="port_ssl" value="443" min="1" max="65535"></td></tr>
     </table><br/>


### PR DESCRIPTION
* Update ConfigMode.h

Corrected Blynk Auth pattern input. "-" and "_" were missing

* Update ConfigMode.h

Corrected Blynk Auth pattern input. "-" and "_" were missing

* Update ConfigMode.h

Corrected Blynk Auth pattern input. "-" and "_" were missing

* Corrected Blynk Auth pattern input.

Corrected Blynk Auth pattern input. "-" and "_" were missing

* Update ConfigMode.h

Corrected Blynk Auth pattern input. "-" and "_" were missing

<!--
Thanks for contributing to Blynk library :-)

Please provide the following information for all PRs.
Replace [brackets] and placeholder text with your responses.
-->

### Description
[Describe what this change achieves]

### Issues Resolved
[List any existing issues this PR resolves; include Fixes #xxx or Closes #xxx (where xxx is issue number)]
